### PR TITLE
Generate random string of 32 characters

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var argv = require('minimist')(process.argv.slice(2));
 // Generate a 256bit AES key
 if (argv._ !== undefined && argv._[0] === 'generate') {
   var randomstring = require('randomstring');
-  console.log(randomstring.generate(33));
+  console.log(randomstring.generate(32));
   process.exit(0);
 }
 


### PR DESCRIPTION
Generate 32 characters instead of 33, else `encrypt-env --write` fails with `Invalid key length`
